### PR TITLE
fix: vercel-cleanurls-false-trailingslash-undefined

### DIFF
--- a/static/vercel.json
+++ b/static/vercel.json
@@ -1,5 +1,4 @@
 {
   "public": true,
-  "cleanUrls": false,
-  "trailingSlash": "undefined"
+  "cleanUrls": false
 }


### PR DESCRIPTION
The previous code used `"undefined"` as a string, instead of the actual value of `undefined`.

Since [JSON can't represent the `undefined` value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#:~:text=undefined%2C%20Function%2C%20and%20Symbol%20values%20are%20not%20valid%20JSON%20values.), the property must be deleted.

